### PR TITLE
fix(ci): update reusable workflow reference to utils

### DIFF
--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -28,7 +28,7 @@ jobs:
 
   # Uses external reusable workflow for day checking logic
   check-day:
-    uses: radicalgrimoire/github-actions-utils/.github/workflows/check-schedule-day.yml@main
+    uses: radicalgrimoire/utils/.github/workflows/check-day.yml@main
     with:
       schedule_type: 'weekly'
       target_value: '1'      # Monday


### PR DESCRIPTION
## Summary
- update reusable workflow reference in build-develop workflow
- replace deprecated github-actions-utils path with utils/check-day

## Why
- fix workflow parsing error: called workflow was not found

## Changes
- .github/workflows/build-develop.yml: update check-day job uses target