### PR TITLE
fix(ci): simplify manual dispatch input and dockerfile default

### DIFF
--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -5,15 +5,7 @@ on:
     # JST 朝9時 = UTC 0時（JST = UTC + 9時間）
     - cron: '0 0 * * *'
   
-  workflow_dispatch:
-    inputs:
-      dockerfile:
-        description: 'Dockerfile to use for building'
-        required: false
-        default: 'Dockerfile'
-        type: choice
-        options:
-          - 'Dockerfile'
+  workflow_dispatch: {}
 
 jobs:
   # Run tests.
@@ -21,9 +13,6 @@ jobs:
   # if: github.event_name == 'push' || github.event_name == 'pull_request'
   test:
     uses: ./.github/workflows/test.yml
-    with:
-      # スケジュール実行時はDockerfile、手動実行時は選択されたファイルを使用
-      docker_files_name: ${{ inputs.dockerfile || 'Dockerfile' }}
     secrets: inherit
 
   # Uses external reusable workflow for day checking logic

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,8 @@ on:
   workflow_call:
     inputs:
       docker_files_name:
-        required: true
+        required: false
+        default: 'Dockerfile'
         type: string
 
 jobs:


### PR DESCRIPTION
## Summary
- simplify workflow_dispatch in build-develop workflow
- remove manual dockerfile input wiring from test reusable workflow call
- set default docker_files_name to Dockerfile in reusable test workflow

## Notes
- behavior for scheduled runs remains Dockerfile by default
